### PR TITLE
when updating an already existing secret, Tags is not a valid parameter

### DIFF
--- a/pysecret/aws.py
+++ b/pysecret/aws.py
@@ -153,6 +153,7 @@ class AWSSecret(object):
         except Exception as e:
             if type(e).__name__ == "ResourceExistsException":
                 create_or_update_secret_kwargs.pop("Name")
+                create_or_update_secret_kwargs.pop("Tags", None)
                 create_or_update_secret_kwargs["SecretId"] = name
                 response = self.sm_client.update_secret(**create_or_update_secret_kwargs)
                 self.secret_cache[name] = None


### PR DESCRIPTION
The update_secret() function call in boto3 doesn't allow the parameter 'Tag' to be set, so it needs to be removed before the update call is made.

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/secretsmanager.html#SecretsManager.Client.update_secret

**Request Syntax**

```
response = client.update_secret(
    SecretId='string',
    ClientRequestToken='string',
    Description='string',
    KmsKeyId='string',
    SecretBinary=b'bytes',
    SecretString='string'
)
```